### PR TITLE
vim: Add fileencoding settings

### DIFF
--- a/common/vimrc
+++ b/common/vimrc
@@ -67,6 +67,7 @@ set nowritebackup
 set noundofile
 set nobackup
 set cmdheight=2
+set fileencodings=utf-8,sjis,cp932,euc-jp
 
 " PlantUML Settings
 let g:plantuml_executable_script = expand('$HOME/dotfiles/common/plantuml/txt2plantuml.sh')


### PR DESCRIPTION
 Add file-encoding settings to make common
 among Windows, macOS and Linux environment.

 refs #5