### PR TITLE
vim: Add vim-markdown settings for macOS environment

### DIFF
--- a/common/vimrc
+++ b/common/vimrc
@@ -94,13 +94,14 @@ augroup MarkdownSettings
   let g:previm_enable_realtime = 1
   if has('win32') || ('win64')
     let g:previm_open_cmd = 'C:\\Program\ Files\ (x86)\\Mozilla\ Firefox\\firefox.exe'
+  elseif has('mac')
+    let g:previm_open_cmd = '/Applications/Firefox.app'
   else
-    " currently do nothing
+    let g:previm_open_cmd = ''
   endif
 augroup END
 
 " NERDTree Settings
 let NERDTreeShowHidden = 1
-"autocmd VimEnter * execute 'NERDTree'
 autocmd VimEnter * if argc() == 0 && !exists("s:std_in") | execute 'NERDTree' | endif
 


### PR DESCRIPTION
 This plugin can preview by setting the path of browser.
 I have already set for Windows environment, but not for macOS.