### PR TITLE
git: Add an including files for my office environment

### DIFF
--- a/common/gitconfig
+++ b/common/gitconfig
@@ -1,6 +1,7 @@
 [Include]
 	path = ~/dotfiles/common/git/gitconfig.alias
 	path = ~/gitconfig.user
+	path = ~/gitconfig.proxy.office
 
 [core]
 	editor = $(which vim)


### PR DESCRIPTION
 Add `$HOME/gitconfig.proxy.office` to
 `Include` section of `$HOME/.gitconfig`.

 There is no side-effect
 even if the file does not exist.

 refs #33