### PR TITLE
ranger: Add settings for Windows

### DIFF
--- a/common/bashrc
+++ b/common/bashrc
@@ -28,6 +28,10 @@ alias :r='vim -R'
 alias :q='exit'
 alias vd='vimdiff'
 
+# ranger
+source ~/dotfiles/common/ranger/ranger.sh
+alias r='_ranger'
+
 # PS1
 export PS1='\[\e[1;35m\]\u:\[\e[1;33m\]\w\[\e[00m\]\[\e[1;31m\]$(__git_ps1)\[\e[00m\]> '
 

--- a/common/ranger/ranger.sh
+++ b/common/ranger/ranger.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 
+readonly UNAME="$(uname)"
+
+if echo "${UNAME}" | grep -i ^mingw.* >/dev/null; then
+	RANGER_EXEC_CMD="ranger.py"
+
+elif [[ "${UNAME}" = "Linux" ]] || [[ "${UNAME}" = "Darwin" ]]; then
+	RANGER_EXEC_CMD="ranger"
+else
+	RANGER_EXEC_CMD="ranger"
+fi
+
 function _ranger() {
 	if [[ -z "${RANGER_LEVEL}" ]]; then
-		ranger
+		${RANGER_EXEC_CMD}
 	else
 		exit
 	fi

--- a/windows/bashrc.local
+++ b/windows/bashrc.local
@@ -8,6 +8,9 @@ GIT_PS1_SHOWDIRTYSTATE=1
 # GIT_PS1_SHOWUNTRACKEDFILES=1
 # GIT_PS1_SHOWSTASHSTATE=1
 
+# PATH
+export PATH="${PATH}:${HOME}/Apps/ranger-1.9.3/"
+
 # Able to create symlink when running by admin user
 export MSYS=winsymlinks:nativestruct
 


### PR DESCRIPTION
To use `ranger` on Windows (MSYS2 x MinGW), it needs to add some settings to files under `dotfiles`.