### PR TITLE
git: Add pathes of the scripts to complete `git`

### DIFF
--- a/osx/bashrc.local
+++ b/osx/bashrc.local
@@ -8,12 +8,16 @@ if [ -f /usr/local/git/git-completion.bash ]; then
 	source /usr/local/git/git-completion.bash
 elif [ -f /usr/local/git/contrib/completion/git-completion.bash ]; then
 	source /usr/local/git/contrib/completion/git-completion.bash
+elif [ -f /usr/local/etc/bash_completion.d/git-completion.bash ]; then
+	source /usr/local/etc/bash_completion.d/git-completion.bash
 fi
 
 if [ -f /usr/local/git/git-prompt.sh ]; then
 	source /usr/local/git/git-prompt.sh
 elif [ -f /usr/local/git/contrib/completion/git-prompt.sh ]; then
 	source /usr/local/git/contrib/completion/git-prompt.sh
+elif [ -f /usr/local/etc/bash_completion.d/git-prompt.sh ]; then
+	source /usr/local/etc/bash_completion.d/git-prompt.sh
 fi
 
 GIT_PS1_SHOWDIRTYSTATE=true


### PR DESCRIPTION
 To adapt changing the pathes of belows;
 * `git-completion.bash`
 * `git-prompt.sh`

 refs #51