### PR TITLE
plantuml: Add an execution parameter

### DIFF
--- a/common/plantuml/txt2plantuml.sh
+++ b/common/plantuml/txt2plantuml.sh
@@ -5,7 +5,7 @@ readonly UNAME="$(uname)"
 
 # Windows with MinGW
 if echo "${UNAME}" | grep -i ^mingw.* > /dev/null; then
-	PLANTUML_CMD="java -jar ${PLANTUML_JAR_BASE} -tpng"
+	PLANTUML_CMD="java -jar ${PLANTUML_JAR_BASE} -tpng -charset UTF-8"
 
 # Linux
 elif [[ "${UNAME}" = "Linux" ]]; then


### PR DESCRIPTION
 Add a parameter `charset UTF-8` on executing
 to prevent garbled characters.

 refs #53