### PR TITLE
vim: Add a plugin of dart

### DIFF
--- a/common/vimrc
+++ b/common/vimrc
@@ -48,6 +48,7 @@ if dein#load_state(s:plugin_dir)
   call dein#add('dhruvasagar/vim-table-mode')
   call dein#add('mattn/vim-sonictemplate')
   call dein#add('lambdalisue/readablefold.vim')
+  call dein#add('dart-lang/dart-vim-plugin')
 
   call dein#end()
   call dein#save_state()


### PR DESCRIPTION
 Add `dart-vim-plugin` to development with Flutter x Vim .

 refs #63