### PR TITLE
git: Set vimdiff as default of `diff.tool`

### DIFF
--- a/common/gitconfig
+++ b/common/gitconfig
@@ -13,6 +13,9 @@
 [color]
 	ui = auto
 
+[diff]
+	tool = vimdiff
+
 [filter "lfs"]
 	clean = git-lfs clean -- %f
 	smudge = git-lfs smudge -- %f


### PR DESCRIPTION
refs #77 
close #77 