### PR TITLE
vim: Split plugin settings to TOML files

### DIFF
--- a/common/vim/dein/dein.toml
+++ b/common/vim/dein/dein.toml
@@ -1,0 +1,58 @@
+# Load always when launching vim
+
+[[plugins]]
+repo = 'Shougo/dein.vim'
+depends = ['wsdjeg/dein-ui.vim']
+
+[[plugins]]
+repo = 'wsdjeg/dein-ui.vim'
+
+[[plugins]]
+repo = 'scrooloose/nerdtree'
+
+[[plugins]]
+repo = 'neoclide/coc.nvim'
+rev = 'release'
+merged = '0'
+
+[[plugins]]
+repo = 'aklt/plantuml-syntax'
+
+[[plugins]]
+repo = 'vim-airline/vim-airline'
+depends = ['vim-airline-themes']
+
+[[plugins]]
+repo = 'vim-airline/vim-airline-themes'
+
+[[plugins]]
+repo = 'tyru/open-browser.vim'
+
+[[plugins]]
+repo = 'godlygeek/tabular'
+depends = ['plasticboy/vim-markdown']
+
+[[plugins]]
+repo = 'plasticboy/vim-markdown'
+
+[[plugins]]
+repo = 'previm/previm'
+
+[[plugins]]
+repo = 'reireias/vim-cheatsheet'
+
+[[plugins]]
+repo = 'simeji/winresizer'
+
+[[plugins]]
+repo = 'dhruvasagar/vim-table-mode'
+
+[[plugins]]
+repo = 'mattn/vim-sonictemplate'
+
+[[plugins]]
+repo = 'lambdalisue/readablefold.vim'
+
+[[plugins]]
+repo = 'dart-lang/dart-vim-plugin'
+

--- a/common/vim/dein/dein_lazy.toml
+++ b/common/vim/dein/dein_lazy.toml
@@ -1,0 +1,2 @@
+# Lazy loading
+

--- a/common/vimrc
+++ b/common/vimrc
@@ -33,23 +33,6 @@ endif
 if dein#load_state(s:plugin_dir)
   call dein#begin(s:plugin_dir)
 
-  call dein#add('scrooloose/nerdtree')
-  call dein#add('neoclide/coc.nvim', {'merged':0, 'rev': 'release'})
-  call dein#add('wsdjeg/dein-ui.vim', {'depends' : 'Shougo/dein.vim'})
-  call dein#add('aklt/plantuml-syntax')
-  call dein#add('vim-airline/vim-airline')
-  call dein#add('vim-airline/vim-airline-themes', {'depends' : 'vim-airline/vim-airline'})
-  call dein#add('tyru/open-browser.vim')
-  call dein#add('godlygeek/tabular')
-  call dein#add('plasticboy/vim-markdown', {'depends' : 'godlygeek/tabular'})
-  call dein#add('previm/previm')
-  call dein#add('reireias/vim-cheatsheet')
-  call dein#add('simeji/winresizer')
-  call dein#add('dhruvasagar/vim-table-mode')
-  call dein#add('mattn/vim-sonictemplate')
-  call dein#add('lambdalisue/readablefold.vim')
-  call dein#add('dart-lang/dart-vim-plugin')
-
   call dein#end()
   call dein#save_state()
 endif

--- a/common/vimrc
+++ b/common/vimrc
@@ -33,6 +33,12 @@ endif
 if dein#load_state(s:plugin_dir)
   call dein#begin(s:plugin_dir)
 
+  let g:dein_toml_dir = expand('~/dotfiles/common/vim/dein')
+  let s:toml = g:dein_toml_dir . '/dein.toml'
+  "let s:lazy_toml = g:dein_toml_dir . '/dein_lazy.toml'
+  call dein#load_toml(s:toml, {'lazy': 0})
+  "call dein#load_toml(s:lazy_toml, {'lazy': 1})
+
   call dein#end()
   call dein#save_state()
 endif


### PR DESCRIPTION
- vim: Add TOML files for "dein.vim"
- vim: Remove plugins descriptions from `.vimrc`
- vim: Load TOML files when vim is launched
