### PR TITLE
wezterm: Set tab title based on `tab_index` instead `tab_id`

### DIFF
--- a/common/wezterm/wezterm.lua
+++ b/common/wezterm/wezterm.lua
@@ -8,7 +8,7 @@ function (tab)
 	if tab.is_active then
 		local tab_text =
 			' '
-			.. tostring(tab.tab_id + 1)
+			.. tostring(tab.tab_index + 1)
 			.. ': '
 			.. tab.active_pane.title
 			.. ' '


### PR DESCRIPTION
 `tab_id` indicates the **physical** identifier for the tab.
 To display tab index in order from the left,
 use `tab_index` instead `tab_id`.

 See at
 [object: TabInformation - Wez's Terminal Emulator](https://wezfurlong.org/wezterm/config/lua/TabInformation.html)

 refs #88, #97
