### PR TITLE
vim: Improve settings

### DIFF
--- a/common/vim/dein/dein.toml
+++ b/common/vim/dein/dein.toml
@@ -34,15 +34,20 @@ repo = 'vim-airline/vim-airline-themes'
 [[plugins]]
 repo = 'tyru/open-browser.vim'
 
-[[plugins]]
-repo = 'godlygeek/tabular'
-depends = ['plasticboy/vim-markdown']
-
-[[plugins]]
-repo = 'plasticboy/vim-markdown'
-
+# https://github.com/previm/previm/
 [[plugins]]
 repo = 'previm/previm'
+hook_add = '''
+  let g:previm_enable_realtime = 1
+  if has('win32') || ('win64')
+    let g:previm_open_cmd = 'C:\\Program\ Files\ (x86)\\Mozilla\ Firefox\\firefox.exe'
+  elseif has('mac')
+    let g:previm_open_cmd = 'open -a Firefox.app'
+  else
+    let g:previm_open_cmd = ''
+  endif
+  nnoremap <silent> <C-p> :PrevimOpen<CR>
+'''
 
 # https://github.com/reireias/vim-cheatsheet
 [[plugins]]

--- a/common/vim/dein/dein.toml
+++ b/common/vim/dein/dein.toml
@@ -34,21 +34,6 @@ repo = 'vim-airline/vim-airline-themes'
 [[plugins]]
 repo = 'tyru/open-browser.vim'
 
-# https://github.com/previm/previm/
-[[plugins]]
-repo = 'previm/previm'
-hook_add = '''
-  let g:previm_enable_realtime = 1
-  if has('win32') || ('win64')
-    let g:previm_open_cmd = 'C:\\Program\ Files\ (x86)\\Mozilla\ Firefox\\firefox.exe'
-  elseif has('mac')
-    let g:previm_open_cmd = 'open -a Firefox.app'
-  else
-    let g:previm_open_cmd = ''
-  endif
-  nnoremap <silent> <C-p> :PrevimOpen<CR>
-'''
-
 # https://github.com/reireias/vim-cheatsheet
 [[plugins]]
 repo = 'reireias/vim-cheatsheet'

--- a/common/vim/dein/dein.toml
+++ b/common/vim/dein/dein.toml
@@ -19,10 +19,18 @@ hook_add = '''
   autocmd VimEnter * if argc() == 0 && !exists("s:std_in") | execute 'NERDTree' | endif
 '''
 
+# https://github.com/neoclide/coc.nvim
 [[plugins]]
 repo = 'neoclide/coc.nvim'
 rev = 'release'
 merged = '0'
+hook_add = '''
+  if has('win32') || has('win64')
+    let g:coc_node_path="C:/Program\ Files/nodejs/node.exe"
+  elseif has('mac')
+    let g:coc_node_path="~/.nodebrew/current/bin/node"
+  endif
+'''
 
 [[plugins]]
 repo = 'vim-airline/vim-airline'

--- a/common/vim/dein/dein.toml
+++ b/common/vim/dein/dein.toml
@@ -7,8 +7,17 @@ depends = ['wsdjeg/dein-ui.vim']
 [[plugins]]
 repo = 'wsdjeg/dein-ui.vim'
 
+# https://github.com/preservim/nerdtree
 [[plugins]]
 repo = 'scrooloose/nerdtree'
+hook_add = '''
+  let NERDTreeShowHidden = 1
+  let NERDTreeIgnore = [
+        \ 'NTUSER.*$',
+        \ '.[oa]$'
+        \]
+  autocmd VimEnter * if argc() == 0 && !exists("s:std_in") | execute 'NERDTree' | endif
+'''
 
 [[plugins]]
 repo = 'neoclide/coc.nvim'

--- a/common/vim/dein/dein.toml
+++ b/common/vim/dein/dein.toml
@@ -51,8 +51,12 @@ repo = 'simeji/winresizer'
 [[plugins]]
 repo = 'dhruvasagar/vim-table-mode'
 
+# https://github.com/mattn/vim-sonictemplate
 [[plugins]]
 repo = 'mattn/vim-sonictemplate'
+hook_add = '''
+  let g:sonictemplate_vim_template_dir = '~/dotfiles/common/vim/template'
+'''
 
 [[plugins]]
 repo = 'lambdalisue/readablefold.vim'

--- a/common/vim/dein/dein.toml
+++ b/common/vim/dein/dein.toml
@@ -38,8 +38,12 @@ repo = 'plasticboy/vim-markdown'
 [[plugins]]
 repo = 'previm/previm'
 
+# https://github.com/reireias/vim-cheatsheet
 [[plugins]]
 repo = 'reireias/vim-cheatsheet'
+hook_add = '''
+  let g:cheatsheet#cheat_file = '~/dotfiles/common/vim/cheatsheet.md'
+'''
 
 [[plugins]]
 repo = 'simeji/winresizer'

--- a/common/vim/dein/dein.toml
+++ b/common/vim/dein/dein.toml
@@ -53,6 +53,3 @@ repo = 'mattn/vim-sonictemplate'
 [[plugins]]
 repo = 'lambdalisue/readablefold.vim'
 
-[[plugins]]
-repo = 'dart-lang/dart-vim-plugin'
-

--- a/common/vim/dein/dein.toml
+++ b/common/vim/dein/dein.toml
@@ -25,9 +25,6 @@ rev = 'release'
 merged = '0'
 
 [[plugins]]
-repo = 'aklt/plantuml-syntax'
-
-[[plugins]]
 repo = 'vim-airline/vim-airline'
 depends = ['vim-airline-themes']
 

--- a/common/vim/dein/dein_lazy.toml
+++ b/common/vim/dein/dein_lazy.toml
@@ -9,3 +9,11 @@ hook_add = '''
   let g:dart_style_guide = 2
 '''
 
+# https://github.com/aklt/plantuml-syntax
+[[plugins]]
+repo = 'aklt/plantuml-syntax'
+on_ft = ['plantuml']
+hook_add = '''
+  let g:plantuml_executable_script = expand('$HOME/dotfiles/common/plantuml/txt2plantuml.sh')
+'''
+

--- a/common/vim/dein/dein_lazy.toml
+++ b/common/vim/dein/dein_lazy.toml
@@ -17,3 +17,19 @@ hook_add = '''
   let g:plantuml_executable_script = expand('$HOME/dotfiles/common/plantuml/txt2plantuml.sh')
 '''
 
+# https://github.com/previm/previm/
+[[plugins]]
+repo = 'previm/previm'
+on_ft = ['markdown']
+hook_add = '''
+  let g:previm_enable_realtime = 1
+  if has('win32') || ('win64')
+    let g:previm_open_cmd = 'C:\\Program\ Files\ (x86)\\Mozilla\ Firefox\\firefox.exe'
+  elseif has('mac')
+    let g:previm_open_cmd = 'open -a Firefox.app'
+  else
+    let g:previm_open_cmd = ''
+  endif
+  nnoremap <silent> <C-p> :PrevimOpen<CR>
+'''
+

--- a/common/vim/dein/dein_lazy.toml
+++ b/common/vim/dein/dein_lazy.toml
@@ -1,2 +1,11 @@
 # Lazy loading
 
+# https://github.com/dart-lang/dart-vim-plugin
+[[plugins]]
+repo = 'dart-lang/dart-vim-plugin'
+on_ft = ['dart']
+hook_add = '''
+  " enable Dart style guide syntax (like 2-space indentation)
+  let g:dart_style_guide = 2
+'''
+

--- a/common/vimrc
+++ b/common/vimrc
@@ -71,19 +71,3 @@ set nobackup
 set cmdheight=2
 set fileencodings=utf-8,sjis,cp932,euc-jp
 
-" Markdown Settings
-augroup MarkdownSettings
-  autocmd!
-  autocmd BufNewFile,BufRead *.{md,mkd} set filetype=markdown
-  nnoremap <silent> <C-p> :PrevimOpen<CR>
-  let g:vim_markdown_folding_disabled = 1
-  let g:previm_enable_realtime = 1
-  if has('win32') || ('win64')
-    let g:previm_open_cmd = 'C:\\Program\ Files\ (x86)\\Mozilla\ Firefox\\firefox.exe'
-  elseif has('mac')
-    let g:previm_open_cmd = 'open -a Firefox.app'
-  else
-    let g:previm_open_cmd = ''
-  endif
-augroup END
-

--- a/common/vimrc
+++ b/common/vimrc
@@ -90,11 +90,3 @@ augroup MarkdownSettings
   endif
 augroup END
 
-" NERDTree Settings
-let NERDTreeShowHidden = 1
-let NERDTreeIgnore = [
-      \ 'NTUSER.*$',
-      \ '.[oa]$'
-      \]
-autocmd VimEnter * if argc() == 0 && !exists("s:std_in") | execute 'NERDTree' | endif
-

--- a/common/vimrc
+++ b/common/vimrc
@@ -2,17 +2,6 @@
 " vim:set ts=8 sts=2 sw=2 tw=0:
 set nocompatible
 
-" Set for Windows environment
-if has('win32') || has('win64')
-  "let $HOME='system('echo "C:/Users/$(whoami)"')'
-  let g:coc_node_path="C:/Program\ Files/nodejs/node.exe"
-endif
-
-" Set for macOS environment
-if has('mac')
-  let g:coc_node_path="~/.nodebrew/current/bin/node"
-endif
-
 " Plugins dir
 let s:plugin_dir = expand('~/.vim/bundle/')
 " Add runtimepath the dir to install dein.vim

--- a/common/vimrc
+++ b/common/vimrc
@@ -45,6 +45,11 @@ endif
 
 filetype plugin indent on
 
+augroup ExtendedFileTypeDetect
+  autocmd!
+  autocmd BufNewFile,BufRead *.uml,*.puml,*.plantuml,*.pu setfiletype plantuml
+augroup END
+
 " Global Settings
 colorscheme desert
 set title

--- a/common/vimrc
+++ b/common/vimrc
@@ -74,9 +74,6 @@ set fileencodings=utf-8,sjis,cp932,euc-jp
 " PlantUML Settings
 let g:plantuml_executable_script = expand('$HOME/dotfiles/common/plantuml/txt2plantuml.sh')
 
-" sonictemplate-vim
-let g:sonictemplate_vim_template_dir = '~/dotfiles/common/vim/template'
-
 " Markdown Settings
 augroup MarkdownSettings
   autocmd!

--- a/common/vimrc
+++ b/common/vimrc
@@ -74,9 +74,6 @@ set fileencodings=utf-8,sjis,cp932,euc-jp
 " PlantUML Settings
 let g:plantuml_executable_script = expand('$HOME/dotfiles/common/plantuml/txt2plantuml.sh')
 
-" Cheetsheat
-let g:cheatsheet#cheat_file = '~/dotfiles/common/vim/cheatsheet.md'
-
 " sonictemplate-vim
 let g:sonictemplate_vim_template_dir = '~/dotfiles/common/vim/template'
 

--- a/common/vimrc
+++ b/common/vimrc
@@ -35,9 +35,9 @@ if dein#load_state(s:plugin_dir)
 
   let g:dein_toml_dir = expand('~/dotfiles/common/vim/dein')
   let s:toml = g:dein_toml_dir . '/dein.toml'
-  "let s:lazy_toml = g:dein_toml_dir . '/dein_lazy.toml'
+  let s:lazy_toml = g:dein_toml_dir . '/dein_lazy.toml'
   call dein#load_toml(s:toml, {'lazy': 0})
-  "call dein#load_toml(s:lazy_toml, {'lazy': 1})
+  call dein#load_toml(s:lazy_toml, {'lazy': 1})
 
   call dein#end()
   call dein#save_state()

--- a/common/vimrc
+++ b/common/vimrc
@@ -71,9 +71,6 @@ set nobackup
 set cmdheight=2
 set fileencodings=utf-8,sjis,cp932,euc-jp
 
-" PlantUML Settings
-let g:plantuml_executable_script = expand('$HOME/dotfiles/common/plantuml/txt2plantuml.sh')
-
 " Markdown Settings
 augroup MarkdownSettings
   autocmd!


### PR DESCRIPTION
- vim: Enable lazy loading of `dein.vim`
- vim: Load `vim-dart-plugin` when Dart sources are opened
- vim: Move `vim-cheatsheet`-related settings to the TOML file
- vim: Move `vim-sonictemplete`-related settings to the TOML file
- vim: Move `nerdtree`-related settings to the TOML file
- vim: Load `plantuml-syntax` when PlantUML sources are opened
- vim: Refine markdown settings
- vim: Load Markdown-related settings when the sources are opened
- vim: Set filetype of `*.{uml,puml,pu,plantuml}` as `plantuml`
- vim: Move `coc.nvim`-related settings to `dein.toml`
