### PR TITLE
bash: Set an alias `hub` instead `gh`

### DIFF
--- a/common/bashrc
+++ b/common/bashrc
@@ -25,6 +25,7 @@ alias :evsp='vim -O'
 alias :r='vim -R'
 alias :q='exit'
 alias vd='vimdiff'
+alias hub='gh'
 
 # ranger
 source ~/dotfiles/common/ranger/ranger.sh
@@ -101,3 +102,4 @@ fi
 
 ## Generated 2022-03-23 02:19:45.807699Z
 ## By /Users/sonod/Apps/flutter/bin/cache/flutter_tools.snapshot
+


### PR DESCRIPTION
 refs #101
