### PR TITLE
vim: Update some settings

### DIFF
--- a/common/vim/cheatsheet.md
+++ b/common/vim/cheatsheet.md
@@ -23,3 +23,15 @@
 | :TableModeDisable | テーブルモードを抜ける                       |
 | :help @en         | 英語版のヘルプを表示する                     |
 
+## coc.nvim
+
+| mode   | cmd | original_cmd                 | description                        |
+|--------|-----|------------------------------|------------------------------------|
+| NORMAL | gd  | <Plug>(coc-definition)       | 定義先ファイルに飛ぶ               |
+| NORMAL | gy  | <Plug>(coc-type-definition)  | typedef の定義先ファイルに飛ぶ     |
+| NORMAL | gi  | <Plug>(coc-implementation)   | 実装先に飛ぶ                       |
+| NORMAL | gr  | <Plug>(coc-references)       | 参照されているリスト               |
+| NORMAL | K   | :call s:show_documentation() | (filetype == vim) ヘルプを表示する |
+|        |     |                              | docs をポップアップ表示する        |
+| NORMAL | F2  | <Plug>(coc-rename)           | 一括リネームする                   |
+

--- a/common/vim/cheatsheet.md
+++ b/common/vim/cheatsheet.md
@@ -18,6 +18,8 @@
 | l                 | 現在のペインを右に拡大する                   |
 | :buffers          | バッファの一覧を表示する                     |
 | :ls               | 同上                                         |
+| :vsp #{buf_num}   | {buf_num} 番目のバッファを垂直分割で開く     |
+| :sp #{buf_num}    | {buf_num} 番目のバッファを水平分割で開く     |
 | :make             | PlantUML 図を生成する                        |
 | :TableModeEnable  | テーブルモードに入る                         |
 | :TableModeDisable | テーブルモードを抜ける                       |

--- a/common/vim/coc/coc-settings.json
+++ b/common/vim/coc/coc-settings.json
@@ -1,0 +1,4 @@
+{
+  "suggest.noselect": true
+}
+

--- a/common/vim/dein/dein.toml
+++ b/common/vim/dein/dein.toml
@@ -46,8 +46,41 @@ hook_add = '''
 [[plugins]]
 repo = 'itchyny/lightline.vim'
 hook_add = '''
+  function! CocCurrentFunction()
+    return get(b:, 'coc_current_function', '')
+  endfunction
+
   let g:lightline = {
   \ 'colorscheme': 'ayu_dark',
+  \ 'active': {
+  \   'left': [
+  \     [ 'mode', 'paste' ],
+  \     [ 'cocstatus', 'currentfunction', 'readonly', 'filename', 'modified' ],
+  \   ],
+  \   'right': [
+  \     [ 'lineinfo' ],
+  \     [ 'percent' ],
+  \     [ 'fileformat', 'fileencoding', 'filetype' ]
+  \   ],
+  \   'component_function': {
+  \     'cocstatus': 'coc#status()',
+  \     'currentfunction': 'CocCurrentFunction'
+  \   }},
+  \ 'inactive': {
+  \   'left': [
+  \     [ 'filename' ]
+  \   ],
+  \   'right': [
+  \     [ 'lineinfo' ],
+  \     [ 'percent' ]
+  \   ]},
+  \ 'tabline': {
+  \   'left': [
+  \     [ 'tabs' ]
+  \   ],
+  \   'right': [
+  \     [ 'close' ]
+  \   ]}
   \ }
 '''
 

--- a/common/vim/dein/dein.toml
+++ b/common/vim/dein/dein.toml
@@ -23,7 +23,10 @@ hook_add = '''
         \ 'NTUSER.*$',
         \ '.[oa]$'
         \]
-  autocmd VimEnter * if argc() == 0 && !exists("s:std_in") | execute 'NERDTree' | endif
+  augroup AutoEnterOnlyGUI
+    autocmd!
+    autocmd GUIEnter * if argc() == 0 && !exists("s:std_in") | execute 'NERDTree' | endif
+  augroup END
 '''
 
 # https://github.com/neoclide/coc.nvim

--- a/common/vim/dein/dein.toml
+++ b/common/vim/dein/dein.toml
@@ -40,6 +40,29 @@ hook_add = '''
   elseif has('mac')
     let g:coc_node_path="~/.nodebrew/current/bin/node"
   endif
+
+  nmap <silent> gd <Plug>(coc-definition)
+  nmap <silent> gy <Plug>(coc-type-definition)
+  nmap <silent> gi <Plug>(coc-implementation)
+  nmap <silent> gr <Plug>(coc-references)
+  nmap <F2> <Plug>(coc-rename)
+
+  function! s:show_documentation()
+    if &filetype == 'vim'
+      execute 'h ' . expand('<cword>')
+    elseif CocAction('hasProvider', 'hover')
+      call CocActionAsync('doHover')
+    else
+      call feedkeys('K', 'in')
+    endif
+  endfunction
+  nnoremap <silent> K :call <SID>show_documentation()<CR>
+
+  augroup HighlightCursorHoldedSymbol
+    autocmd!
+    autocmd CursorHold * silent call CocActionAsync('highlight')
+  augroup END
+
 '''
 
 # https://github.com/itchyny/lightline.vim

--- a/common/vim/dein/dein.toml
+++ b/common/vim/dein/dein.toml
@@ -42,12 +42,14 @@ hook_add = '''
   endif
 '''
 
+# https://github.com/itchyny/lightline.vim
 [[plugins]]
-repo = 'vim-airline/vim-airline'
-depends = ['vim-airline-themes']
-
-[[plugins]]
-repo = 'vim-airline/vim-airline-themes'
+repo = 'itchyny/lightline.vim'
+hook_add = '''
+  let g:lightline = {
+  \ 'colorscheme': 'ayu_dark',
+  \ }
+'''
 
 [[plugins]]
 repo = 'tyru/open-browser.vim'

--- a/common/vim/dein/dein.toml
+++ b/common/vim/dein/dein.toml
@@ -77,3 +77,12 @@ hook_add = '''
 [[plugins]]
 repo = 'lambdalisue/readablefold.vim'
 
+# https://github.com/Shougo/context_filetype.vim
+[[plugins]]
+repo = 'Shougo/context_filetype.vim'
+
+# https://github.com/osyo-manga/vim-precious
+[[plugins]]
+repo = 'osyo-manga/vim-precious'
+depends = ['Shougo/context_filetype.vim']
+

--- a/common/vim/dein/dein.toml
+++ b/common/vim/dein/dein.toml
@@ -33,7 +33,7 @@ hook_add = '''
 [[plugins]]
 repo = 'neoclide/coc.nvim'
 rev = 'release'
-merged = '0'
+merged = 0
 hook_add = '''
   if has('win32') || has('win64')
     let g:coc_node_path="C:/Program\ Files/nodejs/node.exe"

--- a/common/vimrc
+++ b/common/vimrc
@@ -1,6 +1,8 @@
 " My vimrc
 " vim:set ts=8 sts=2 sw=2 tw=0:
-set nocompatible
+if &compatible
+  set nocompatible
+endif
 
 " Plugins dir
 let s:plugin_dir = expand('~/.vim/bundle/')

--- a/common/vimrc
+++ b/common/vimrc
@@ -67,4 +67,5 @@ set nobackup
 set cmdheight=2
 set fileencodings=utf-8,sjis,cp932,euc-jp
 set wildmenu
+set signcolumn=yes
 


### PR DESCRIPTION
- vim: Disable to run NERDTree when startup without arguments
- vim: Set `nocompatible` if `compatible` is set
- vim: Always show `signcolumn`
- vim: Fix `dein.toml` suggested by `coc-toml`
- vim: Use `lightline.vim` instead `vim-airline` to show statusline
- vim: Add `vim-precious`
- vim: Manage `coc-settings.json` by Git
- vim: Show the status of `coc.nvim` by `lightline.vim`
- vim: Add key-mappings for `coc.nvim`
- vim: Update my cheatsheet

Close #105