### PR TITLE
vim: Display full-width symbols correctly

### DIFF
--- a/common/vimrc
+++ b/common/vimrc
@@ -68,4 +68,5 @@ set cmdheight=2
 set fileencodings=utf-8,sjis,cp932,euc-jp
 set wildmenu
 set signcolumn=yes
+set ambiwidth=double
 


### PR DESCRIPTION
 To realize above, it is necessary to add
 `set ambiwidth=double`.

Close #109
