### PR TITLE
bash: Set PATH of Rust toolchain

### DIFF
--- a/osx/bash_profile.local
+++ b/osx/bash_profile.local
@@ -12,3 +12,6 @@ export FVM_HOME="$HOME/.fvm"
 export PATH="$PATH:$HOME/.pub-cache/bin:$FVM_HOME/default/bin"
 export CHROME_EXECUTABLE='/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge'
 
+# Rust w/ rustup
+source ~/.cargo/env
+


### PR DESCRIPTION
 `~/.cargo/env` is automatically generated by `rustup`.

Related to PR #108 
Close #107 
