### PR TITLE
vim: Change filer plugin to `fern.vim`

### DIFF
--- a/vim/dein/dein.toml
+++ b/vim/dein/dein.toml
@@ -18,6 +18,10 @@ hook_add = '''
 [[plugins]]
 repo = 'lambdalisue/fern.vim'
 hook_add = '''
+  augroup AutoRunOnlyGUI
+    autocmd!
+    autocmd GUIEnter * ++nested Fern ~/ -drawer -reveal=%
+  augroup END
 '''
 
 # https://github.com/neoclide/coc.nvim

--- a/vim/dein/dein.toml
+++ b/vim/dein/dein.toml
@@ -14,6 +14,12 @@ hook_add = '''
   set helplang=ja,en
 '''
 
+# https://github.com/lambdalisue/fern.vim
+[[plugins]]
+repo = 'lambdalisue/fern.vim'
+hook_add = '''
+'''
+
 # https://github.com/neoclide/coc.nvim
 [[plugins]]
 repo = 'neoclide/coc.nvim'

--- a/vim/dein/dein.toml
+++ b/vim/dein/dein.toml
@@ -14,21 +14,6 @@ hook_add = '''
   set helplang=ja,en
 '''
 
-# https://github.com/preservim/nerdtree
-[[plugins]]
-repo = 'scrooloose/nerdtree'
-hook_add = '''
-  let NERDTreeShowHidden = 1
-  let NERDTreeIgnore = [
-        \ 'NTUSER.*$',
-        \ '.[oa]$'
-        \]
-  augroup AutoEnterOnlyGUI
-    autocmd!
-    autocmd GUIEnter * if argc() == 0 && !exists("s:std_in") | execute 'NERDTree' | endif
-  augroup END
-'''
-
 # https://github.com/neoclide/coc.nvim
 [[plugins]]
 repo = 'neoclide/coc.nvim'


### PR DESCRIPTION
- vim: Remove `NERDTree` (3251adeeb7e5dccd21f34f4d357c6f047fdaf31d)
- vim: Add `fern.vim` (60c475f5323f718888c9ece3d053f2acb6183941)
- vim: Open `fern.vim` as drawer style when GVim starts (f05870fdfa4d467193d95bbf3563f41175c5134a)

Closes #120 