### PR TITLE
bash: Fix the path of `bash_profile` of each OS

### DIFF
--- a/bash/bash_profile
+++ b/bash/bash_profile
@@ -4,8 +4,8 @@
 source ~/dotfiles/env/environment_vars
 
 # Load `bash_profile.local` for each platforms
-if [[ -f ~/dotfiles/${DOTFILES_ENV_OS}/bash_profile ]]; then
-	source ~/dotfiles/${DOTFILES_ENV_OS}/bash_profile
+if [[ -f ~/dotfiles/bash/${DOTFILES_ENV_OS}/bash_profile ]]; then
+	source ~/dotfiles/bash/${DOTFILES_ENV_OS}/bash_profile
 fi
 
 if [[ -f ~/.bashrc ]]; then


### PR DESCRIPTION
 This bug may be caused by
 commit 273241e16185b76dc7dd7dd6df96f517e53d5b88 and
 commit 6e4a278437af3f543bd97932a7ec8b864b58a41f .

Closes #122 