### PR TITLE
vim: Support `*.hjson`

### DIFF
--- a/vim/dein/dein_lazy.toml
+++ b/vim/dein/dein_lazy.toml
@@ -41,3 +41,8 @@ hook_add = '''
   let g:rustfmt_autosave = 1
 '''
 
+# https://github.com/hjson/vim-hjson
+[[plugins]]
+repo = 'hjson/vim-hjson'
+on_ft = ['hjson']
+


### PR DESCRIPTION
 Install a small plugin that provides the syntax highlighting
 for Hjson format.

 Close #128 