### PR TITLE
editorconfig: Add settings and a plugin for Vim

### DIFF
--- a/editorconfig/editorconfig
+++ b/editorconfig/editorconfig
@@ -1,0 +1,48 @@
+# Global .editorconfig
+
+root = true
+
+[*]
+indent_style = tab
+tab_width = 8
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.{md,mkd}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+[*.{uml,puml,plantuml,pu}]
+indent_style = space
+indent_size = 2
+
+[*.{json,hjson}]
+indent_style = space
+indent_size = 2
+
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2
+
+[*.toml]
+indent_style = space
+indent_size = 2
+
+[**/{vim,gvim}rc]
+indent_style = space
+indent_size = 2
+
+[*.dart]
+indent_style = space
+indent_size = 2
+
+[*.rs]
+indent_style = space
+indent_size = 4
+
+[*.py]
+indent_style = space
+indent_size = 4
+

--- a/setup.sh
+++ b/setup.sh
@@ -194,6 +194,13 @@ else
 	ln -sfv ~/dotfiles/gh/config.yml ~/.config/gh/config.yml
 fi
 
+# editorconfig
+if [[ "${DEBUG_MODE}" == "true" ]]; then
+	echo -e "\tln -sfv ~/dotfiles/editorconfig/editorconfig ~/.editorconfig"
+else
+	ln -sfv ~/dotfiles/editorconfig/editorconfig ~/.editorconfig
+fi
+
 echo "### Done. ###"
 exit 0
 

--- a/vim/dein/dein.toml
+++ b/vim/dein/dein.toml
@@ -137,3 +137,7 @@ repo = 'Shougo/context_filetype.vim'
 repo = 'osyo-manga/vim-precious'
 depends = ['Shougo/context_filetype.vim']
 
+# https://github.com/editorconfig/editorconfig-vim
+[[plugins]]
+repo = 'editorconfig/editorconfig-vim'
+

--- a/vim/gvimrc
+++ b/vim/gvimrc
@@ -1,5 +1,4 @@
 " My gvimrc
-" vim:set ts=8 sts=2 sw=2 tw=0:
 
 colorscheme desert
 

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -1,5 +1,4 @@
 " My vimrc
-" vim:set ts=8 sts=2 sw=2 tw=0:
 if &compatible
   set nocompatible
 endif


### PR DESCRIPTION
* 2c4edee6a5a9032ad824c068b75b4f80beaccbcc
  - Add [editorconfig-vim](https://github.com/editorconfig/editorconfig-vim) via dein
* 2c253b3563c0e273a8cdb8b624f6a34f768a80a5
  - Create a global config file
* 104bce9ab28198856a908b8073f687c73ccdda08
  - Make a symlink under `$HOME` to the global config file
* 9cbef1588064dc55232ece9347b3bc15cab9f15a
  - The line `vim: set ts=...` is no longer needed

Close #135 