### PR TITLE
plantuml: Update from `2021.16` to `2023.10`

### DIFF
--- a/plantuml/bin/plantuml.jar
+++ b/plantuml/bin/plantuml.jar
@@ -1,1 +1,1 @@
-plantuml-1.2021.16.jar
+plantuml-1.2023.10.jar


### PR DESCRIPTION
Update the execution binary `plantuml.jar` to [Release v1.2023.10 · plantuml/plantuml](https://github.com/plantuml/plantuml/releases/tag/v1.2023.10) .

close #55 