### PR TITLE
Rust: Load settings only if `DOTFILES_ENV_CONFIG_RUST_ENABLE` is set

### DIFF
--- a/bash/bash_profile
+++ b/bash/bash_profile
@@ -3,6 +3,11 @@
 # Set environment vars
 source ~/dotfiles/env/environment_vars
 
+# Rust
+if [[ ${DOTFILES_ENV_CONFIG_RUST_ENABLE} == "y" ]]; then
+	source ~/.cargo/env
+fi
+
 # Load `bash_profile.local` for each platforms
 if [[ -f ~/dotfiles/bash/${DOTFILES_ENV_OS}/bash_profile ]]; then
 	source ~/dotfiles/bash/${DOTFILES_ENV_OS}/bash_profile

--- a/bash/macos/bash_profile
+++ b/bash/macos/bash_profile
@@ -14,6 +14,3 @@ if [[ ${DOTFILES_ENV_CONFIG_FLUTTER_ENABLE} = "y" ]]; then
 	export CHROME_EXECUTABLE='/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge'
 fi
 
-# Rust w/ rustup
-source ~/.cargo/env
-


### PR DESCRIPTION
close #146