### PR TITLE
tig: Add a shortcut to revert commits

### DIFF
--- a/tig/tigrc
+++ b/tig/tigrc
@@ -7,3 +7,5 @@
 bind main R !git rebase -i %(commit)
 bind diff R !git rebase -i %(commit)
 
+bind main V !git revert %(commit)
+


### PR DESCRIPTION
 When pressed `Shift+v` on `view-main` page of tig,
 it will do git-revert to the selected commit.

 resolves #149