### PR TITLE
gh: Add an alias to lint workflow files

### DIFF
--- a/gh/config.yml
+++ b/gh/config.yml
@@ -9,6 +9,7 @@ pager:
 # Aliases allow you to create nicknames for gh commands
 aliases:
     co: pr checkout
+    workflow lint: '!actionlint -verbose -shellcheck=$(which shellcheck) "$1"'
 # The path to a unix socket through which send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.
 http_unix_socket:
 # What web browser gh should use when opening URLs. If blank, will refer to environment.


### PR DESCRIPTION
To use it, you need to install followings into your machine.

* https://github.com/rhysd/actionlint
* https://www.shellcheck.net/

resolves #157