### PR TITLE
bash: Introduce bash-completion for newly (4.2+) version

### DIFF
--- a/bash/macos/bash_profile
+++ b/bash/macos/bash_profile
@@ -1,6 +1,10 @@
 # Homebrew
 export PATH="/opt/homebrew/bin:$PATH"
 
+# bash-completion
+[[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" ]] \
+	&& . "/opt/homebrew/etc/profile.d/bash_completion.sh"
+
 # Node.js
 export PATH="$PATH:/Users/$(whoami)/.nodebrew/current/bin"
 


### PR DESCRIPTION
 It provides as `bash-completion@2` on homebrew formula.

 refs #159