### PR TITLE
rancher-desktop: Set PATH to the bin dir

### DIFF
--- a/bash/macos/bash_profile
+++ b/bash/macos/bash_profile
@@ -18,3 +18,7 @@ if [[ ${DOTFILES_ENV_CONFIG_FLUTTER_ENABLE} = "y" ]]; then
 	export CHROME_EXECUTABLE='/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge'
 fi
 
+# Rancher Desktop
+[[ ${DOTFILES_ENV_CONFIG_RANCHER_DESKTOP_ENABLE} = "y" ]] && [[ -d "$HOME/.rd/bin" ]] \
+	&& export PATH="$PATH:$HOME/.rd/bin"
+


### PR DESCRIPTION
 If both `DOTFILES_ENV_CONFIG_RANCHER_DESKTOP_ENABLE` and
 the existance of `$HOME/.rd/bin/ are true,
 add their path to `$PATH` .

 resolves #171