### PR TITLE
tig: Allow auto-squashing when to rebase

### DIFF
--- a/tig/tigrc
+++ b/tig/tigrc
@@ -4,7 +4,7 @@
 # NOTE: Overwrite "Reload & refresh view" func.
 # URI: https://qiita.com/numanomanu/items/513d62fb4a7921880085#_reference-db4b533640452a36cf63
 
-bind main R !git rebase -i %(commit)
+bind main R !git rebase -i --autosquash %(commit)
 bind diff R !git rebase -i %(commit)
 
 bind main V !git revert %(commit)


### PR DESCRIPTION
 If the branch contains the commits which starts to
 name `{Fixup!, Squash!}`, Git can {fixup, squash} them
 with `--autosquash` option.

 resolves #174