### PR TITLE
fvm: Change the name of environment variable

### DIFF
--- a/bash/macos/bash_profile
+++ b/bash/macos/bash_profile
@@ -13,7 +13,7 @@ export PATH="/usr/local/opt/ruby/bin:$PATH"
 
 # Flutter
 if [[ ${DOTFILES_ENV_CONFIG_FLUTTER_ENABLE} = "y" ]]; then
-	export FVM_HOME="$HOME/.fvm"
+	export FVM_CACHE_PATH="$HOME/.fvm"
 	export PATH="$PATH:$HOME/.pub-cache/bin:$FVM_HOME/default/bin"
 	export CHROME_EXECUTABLE='/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge'
 fi


### PR DESCRIPTION
 From FVM v3, it is necessary to set the cache path of Flutter SDK
 into `FVM_CACHE_PATH` instead `FVM_HOME` .

 resolves #182