### PR TITLE
vim: Update cheatsheet.md

### DIFF
--- a/vim/cheatsheet.md
+++ b/vim/cheatsheet.md
@@ -2,27 +2,30 @@
 
 ## Built-In and misc
 
-| mode            | cmd                 | description                              |
-|-----------------|---------------------|------------------------------------------|
-| COMMAND         | tabnew              | タブを新規に開く                         |
-| NORMAL          | gt                  | 次のタブに移動する                       |
-| NORMAL          | gT                  | 前のタブに移動する                       |
-| COMMAND         | :nohl               | 検索した単語のハイライトを解除する       |
-| COMMAND         | :%!xxd              | hexdump っぽく変換する                   |
-| COMMAND         | :buffers            | バッファの一覧を表示する                 |
-| COMMAND         | :ls                 | 同上                                     |
-| COMMAND         | :vsp #{buf_num}     | {buf_num} 番目のバッファを垂直分割で開く |
-| COMMAND         | :sp #{buf_num}      | {buf_num} 番目のバッファを水平分割で開く |
-| COMMAND         | :make               | PlantUML 図を生成する                    |
-| COMMAND         | :help @en           | 英語版のヘルプを表示する                 |
-| COMMAND         | :echo {VAR}         | 変数 {VAR} の中身を表示する              |
-| COMMAND         | :echo &{OPTION}     | オプション {OPTION} の中身を表示する     |
-| COMMAND         | :e ++ff=unix        | fileformat を UNIX (LF) で開き直す       |
-| COMMAND         | :setl ff=unix       | 同上                                     |
-| COMMAND, INSERT | C-v + C-m           | CR 制御文字 (^M) を打つ                  |
-| COMMAND         | :echo expand('%')   | 相対パスでファイル名を取得する           |
-| COMMAND         | :echo expand('%:p)' | 絶対パスでファイル名を取得する           |
-| COMMAND         | :r! $(shellcmd)     | $(shellcmd) の実行結果を挿入する         |
+| mode            | cmd                 | description                                    |
+|-----------------|---------------------|------------------------------------------------|
+| COMMAND         | tabnew              | タブを新規に開く                               |
+| NORMAL          | gt                  | 次のタブに移動する                             |
+| NORMAL          | gT                  | 前のタブに移動する                             |
+| COMMAND         | :nohl               | 検索した単語のハイライトを解除する             |
+| COMMAND         | :%!xxd              | hexdump っぽく変換する                         |
+| COMMAND         | :buffers            | バッファの一覧を表示する                       |
+| COMMAND         | :ls                 | 同上                                           |
+| COMMAND         | :vsp #{buf_num}     | {buf_num} 番目のバッファを垂直分割で開く       |
+| COMMAND         | :sp #{buf_num}      | {buf_num} 番目のバッファを水平分割で開く       |
+| COMMAND         | :make               | PlantUML 図を生成する                          |
+| COMMAND         | :help @en           | 英語版のヘルプを表示する                       |
+| COMMAND         | :echo {VAR}         | 変数 {VAR} の中身を表示する                    |
+| COMMAND         | :echo &{OPTION}     | オプション {OPTION} の中身を表示する           |
+| COMMAND         | :e ++ff=unix        | fileformat を UNIX (LF) で開き直す             |
+| COMMAND         | :setl ff=unix       | 同上                                           |
+| COMMAND, INSERT | C-v + C-m           | CR 制御文字 (^M) を打つ                        |
+| COMMAND         | :echo expand('%')   | 相対パスでファイル名を取得する                 |
+| COMMAND         | :echo expand('%:p)' | 絶対パスでファイル名を取得する                 |
+| COMMAND         | :r! $(shellcmd)     | $(shellcmd) の実行結果を挿入する               |
+| NORMAL          | ~                   | カーソル下の英字を {大文字, 小文字} に変換する |
+| NORMAL          | g{u, U, ~}          | u は小文字, U は大文字, ~ は現在と逆           |
+|                 |                     | `guiw` でカーソル下の単語をすべて小文字にする  |
 
 ## vimdiff
 


### PR DESCRIPTION
 Add a tip how to convert the character under the cursor to upper or lower case.
 [vim-jp » Hack #166: ローマ字の大文字/小文字を変換する](https://vim-jp.org/vim-users-jp/2010/08/08/Hack-166.html)

 resolves #190