### PR TITLE
git: Update an alias `pf`

### DIFF
--- a/git/alias
+++ b/git/alias
@@ -2,7 +2,7 @@
 	st = status
 	pl = pull
 	pu = push -u
-	pf = push --force-with-lease
+	pf = push --force-with-lease --force-if-includes
 	pd = push --delete
 	br = branch
 	bd = branch -d


### PR DESCRIPTION
 To be more safely to force-push,
 add `--force-if-includes` into the argument of `pf` .

resolves #192