### PR TITLE
git: Set default branch name as `main` when initializing

### DIFF
--- a/git/config
+++ b/git/config
@@ -20,6 +20,9 @@
 [diff]
 	tool = vimdiff
 
+[init]
+	defaultBranch = main
+
 [filter "lfs"]
 	clean = git-lfs clean -- %f
 	smudge = git-lfs smudge -- %f


### PR DESCRIPTION
resolves #196