### PR TITLE
vim: Add `unsigned` to nrformats opt

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -69,4 +69,5 @@ set fileencodings=utf-8,sjis,cp932,euc-jp
 set wildmenu
 set signcolumn=yes
 set ambiwidth=double
+set nrformats=unsigned,bin,hex
 


### PR DESCRIPTION
 [Vim で <C-a> <C-x> でインクリメント/ディクリメントする際に符号を無視する](https://zenn.dev/mamayukawaii/articles/20240629013553)

 resolves #202