### PR TITLE
yazi: Modify its executing function name

### DIFF
--- a/bash/bashrc
+++ b/bash/bashrc
@@ -37,7 +37,7 @@ fi
 
 # yazi
 source ~/dotfiles/yazi/yazi.sh
-alias y='_yazi'
+alias y='_yazi_exec'
 
 # docker
 source ~/dotfiles/docker/docker.sh

--- a/yazi/yazi.sh
+++ b/yazi/yazi.sh
@@ -6,7 +6,7 @@ if [[ ${DOTFILES_ENV_CONFIG_YAZI_ENABLE} == 'y' ]]; then
 	YAZI_EXEC_CMD="yazi"
 fi
 
-function _yazi() {
+function _yazi_exec() {
 	if [[ -z "${YAZI_LEVEL}" ]]; then
 		${YAZI_EXEC_CMD}
 	else

--- a/yazi/yazi.sh
+++ b/yazi/yazi.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# shellcheck source=/dev/null
 source ~/dotfiles/env/environment_vars
 
 if [[ ${DOTFILES_ENV_CONFIG_YAZI_ENABLE} == 'y' ]]; then


### PR DESCRIPTION
 `_yazi()` is duplicated to the yazi-official built-in function.

 closes #251 