### PR TITLE
neovim: Update LSP settings

### DIFF
--- a/neovim/lazy-lock.json
+++ b/neovim/lazy-lock.json
@@ -17,7 +17,7 @@
   "mini.nvim": { "branch": "main", "commit": "94cae4660a8b2d95dbbd56e1fbc6fcfa2716d152" },
   "nui.nvim": { "branch": "main", "commit": "de740991c12411b663994b2860f1a4fd0937c130" },
   "nvim-cmp": { "branch": "main", "commit": "d97d85e01339f01b842e6ec1502f639b080cb0fc" },
-  "nvim-lspconfig": { "branch": "master", "commit": "a2bd1cf7b0446a7414aaf373cea5e4ca804c9c69" },
+  "nvim-lspconfig": { "branch": "master", "commit": "0b38bc74487e73489624d61396af7805af9cc75f" },
   "nvim-treesitter": { "branch": "master", "commit": "42fc28ba918343ebfd5565147a42a26580579482" },
   "nvim-web-devicons": { "branch": "master", "commit": "8dcb311b0c92d460fac00eac706abd43d94d68af" },
   "outline.nvim": { "branch": "main", "commit": "6b62f73a6bf317531d15a7ae1b724e85485d8148" },

--- a/neovim/lua/plugins/lsp.lua
+++ b/neovim/lua/plugins/lsp.lua
@@ -7,7 +7,7 @@ local lsp_servers = {
     "bashls",
     "lua_ls",
     "eslint",
-    "ts_ls",
+    "tsserver",
     "yamlls",
 }
 
@@ -15,19 +15,19 @@ return {
     {
         "williamboman/mason.nvim",
         dependencies = {
-            "williamboman/mason-lspconfig.nvim",
             "neovim/nvim-lspconfig",
+            "williamboman/mason-lspconfig.nvim",
         },
         config = function()
             require("mason").setup()
             require("mason-lspconfig").setup({
                 ensure_installed = lsp_servers,
             })
-            local lsp_config = require("lspconfig")
             for _, lsp_server in ipairs(lsp_servers) do
-                lsp_config[lsp_server].setup({
+                vim.lsp.config(lsp_server, {
                     root_dir = function(fname)
-                        return lsp_config.util.find_git_ancestor(fname) or vim.fn.getcwd()
+                        local lspconfig_util = require("lspconfig.util")
+                        return lspconfig_util.find_git_ancestor(fname) or vim.fn.getcwd()
                     end,
                 })
             end


### PR DESCRIPTION
`require("lspconfig")` will be deprecated on nvim-lspconfig v3,
so that it is needed to rewrite LSP settings.

closes #256
