### PR TITLE
neovim: Check whether fname is number or not

### DIFF
--- a/neovim/lua/plugins/lsp.lua
+++ b/neovim/lua/plugins/lsp.lua
@@ -27,6 +27,9 @@ return {
                 vim.lsp.config(lsp_server, {
                     root_dir = function(fname)
                         local lspconfig_util = require("lspconfig.util")
+                        if type(fname) == "number" then
+                            fname = vim.api.nvim_buf_get_name(fname)
+                        end
                         return lspconfig_util.find_git_ancestor(fname) or vim.fn.getcwd()
                     end,
                 })


### PR DESCRIPTION
Normally, `fname` is a string, but in some case, it isn't.

closes #283
