### PR TITLE
editorconfig: Add settings for RON

### DIFF
--- a/editorconfig/editorconfig
+++ b/editorconfig/editorconfig
@@ -38,7 +38,7 @@ indent_size = 2
 indent_style = space
 indent_size = 2
 
-[*.rs]
+[*.{rs,ron}]
 indent_style = space
 indent_size = 4
 


### PR DESCRIPTION
RON; Rusty Object Notation, which is used mainly for Rust apps.

closes #289
