### PR TITLE
neovim: Set key bindings for copilot.lua

### DIFF
--- a/neovim/lua/plugins/copilot.lua
+++ b/neovim/lua/plugins/copilot.lua
@@ -8,7 +8,10 @@ return {
             suggestion = {
                 auto_trigger = true,
                 keymap = {
-                    accept = "<Tab>",
+                    accept = "<M-l>",
+                    next = "<M-]>",
+                    prev = "<M-[>",
+                    dismiss = "<C-]>",
                 },
             },
         },


### PR DESCRIPTION
To avoid duplicated bindings for another plugins.

closes #293
